### PR TITLE
Update php_fpm_error_log to accommodate v7

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,17 @@ Role Variables
 
 The role uses the following variables:
 
+ - **php_fpm_version**: The version of php to be installed.  Defaults to "5.6". 
+   **Note** this must include both the major version number and the minor version 
+   number/ mantissa.
  - **php_fpm_pools**: The list a pools for php-fpm, each pools is a hash with
    a name entry (used for filename), all the other entries in the hash are pool
    directives (see http://php.net/manual/en/install.fpm.configuration.php).
  - **php_fpm_pool_defaults**: A list of default directives used for all php-fpm pools
    (see http://php.net/manual/en/install.fpm.configuration.php).
- - **php_fpm_apt_packages**: The list of packages to be installed by the
-  ```apt```, defaults to ```[php5-fpm]```.
-   module.
+ - **php_fpm_apt_packages**: The list of packages to be installed by the ```apt``` module. 
+    Defaults to ```[php5-fpm]``` or ```[php-fpm]``` depending on the ```php_fpm_version``` 
+    specified.
  - **php_fpm_yum_packages**: The list of packages to be installed by the
    ```yum``` module, defaults to ```[php-fpm]```.
  - **php_fpm_ini**: Customization for php-fpm's php.ini as a list of options,
@@ -32,8 +35,6 @@ The role uses the following variables:
      - **section**: Section name in INI file.
  - **php_fpm_config**: Customization for php-fpm's configuration file as a list
    of options.
- - **php_fpm_apt_packages**: The APT packages to install, defaults to ```[php5-fpm]```.
- - **php_fpm_yum_packages**: The Yum packages to install, defaults to ```[php-fpm]```.
  - **php_fpm_default_pool**:
      - **delete**: Set to a ```True``` value to delete the default pool.
      - **name**: The filename the default pool configuration file.
@@ -42,6 +43,7 @@ Example configuration
 --------------
 
     - role: php-fpm
+      php_fpm_version: 7.0
       php_fpm_pool_defaults:
         pm: dynamic
         pm.max_children: 5

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -42,4 +42,4 @@ php_fpm_ini:
 php_fpm_config:
  - option: "error_log"
    section: "global"
-   value: "/var/log/php5-fpm.log"
+   value: '{{ php_fpm_error_log }}'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,7 +8,7 @@
        - default.yml
       paths:
        - "../vars/"
- 
+
 - name: Install the php packages (APT)
   apt: >
     name={{ item }}
@@ -112,7 +112,7 @@
   changed_when: "result.rc != 0"
   tags: [configuration,php,fpm]
 
-- name: Start the php5-fpm service
+- name: Start the php-fpm service
   service:
     name={{ php_fpm_service_name }}
     state=started

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -11,6 +11,7 @@ php_fpm_vars:
     php_fpm_service_name: php5-fpm
 
     php_fpm_pid_file: /var/run/php5-fpm.pid
+    php_fpm_error_log: /var/log/php5-fpm.log
 
   v7:
     php_fpm_ini_path: /etc/php/7.0/fpm/php.ini
@@ -21,10 +22,12 @@ php_fpm_vars:
     php_fpm_service_name: php7.0-fpm
 
     php_fpm_pid_file: /var/run/php-fpm.pid
+    php_fpm_error_log: /var/log/php-fpm.log
 
 php_fpm_ini_path: "{{ php_fpm_vars[branch]['php_fpm_ini_path']}}"
 php_fpm_config_path: "{{ php_fpm_vars[branch]['php_fpm_config_path']}}"
 php_fpm_pool_d: "{{ php_fpm_vars[branch]['php_fpm_pool_d']}}"
+php_fpm_error_log: "{{ php_fpm_vars[branch]['php_fpm_error_log']}}"
 
 php_fpm_binary_name: "{{ php_fpm_vars[branch]['php_fpm_binary_name']}}"
 php_fpm_service_name: "{{ php_fpm_vars[branch]['php_fpm_service_name']}}"


### PR DESCRIPTION
Previously the module was setting the `php_fpm_error_log` to `php5-fpm.log` even for php 7.

(Also updated the README to tell people about the version setting)
